### PR TITLE
docs(guide/expression): add clarification for RegExp literal in `ngPa…

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -37,7 +37,8 @@ AngularJS expressions are like JavaScript expressions with the following differe
     even inside `ng-init` directive.
 
   * **No RegExp Creation With Literal Notation:** You cannot create regular expressions
-    in an AngularJS expression.
+    in an AngularJS expression. An exception to this rule is {@link ngPattern `ng-pattern`} which accepts valid
+    RegExp.
 
   * **No Object Creation With New Operator:** You cannot use `new` operator in an AngularJS expression.
 


### PR DESCRIPTION
…ttern` expression

The `ngPattern` expression does accept a RegExp created with literal notation,
hence it should be mentioned as an exception to the
"No RegExp Creation With Literal Notation" rule.

Closes #16206

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

