### PR TITLE
Update upstream

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -104,6 +104,7 @@ var angularFiles = {
       'src/ngAnimate/animateJs.js',
       'src/ngAnimate/animateJsDriver.js',
       'src/ngAnimate/animateQueue.js',
+      'src/ngAnimate/animateCache.js',
       'src/ngAnimate/animation.js',
       'src/ngAnimate/ngAnimateSwap.js',
       'src/ngAnimate/module.js'

--- a/src/ngAnimate/.eslintrc.json
+++ b/src/ngAnimate/.eslintrc.json
@@ -73,6 +73,7 @@
     /* ngAnimate directives/services */
     "ngAnimateSwapDirective": true,
     "$$rAFSchedulerFactory": true,
+    "$$AnimateCacheProvider": true,
     "$$AnimateChildrenDirective": true,
     "$$AnimateQueueProvider": true,
     "$$AnimationProvider": true,

--- a/src/ngAnimate/animateCache.js
+++ b/src/ngAnimate/animateCache.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/** @this */
+var $$AnimateCacheProvider = function() {
+
+  var KEY = '$$ngAnimateParentKey';
+  var parentCounter = 0;
+  var cache = Object.create(null);
+
+  this.$get = [function() {
+    return {
+      cacheKey: function(node, method, addClass, removeClass) {
+        var parentNode = node.parentNode;
+        var parentID = parentNode[KEY] || (parentNode[KEY] = ++parentCounter);
+        var parts = [parentID, method, node.getAttribute('class')];
+        if (addClass) {
+          parts.push(addClass);
+        }
+        if (removeClass) {
+          parts.push(removeClass);
+        }
+        return parts.join(' ');
+      },
+
+      containsCachedAnimationWithoutDuration: function(key) {
+        var entry = cache[key];
+
+        // nothing cached, so go ahead and animate
+        // otherwise it should be a valid animation
+        return (entry && !entry.isValid) || false;
+      },
+
+      flush: function() {
+        cache = Object.create(null);
+      },
+
+      count: function(key) {
+        var entry = cache[key];
+        return entry ? entry.total : 0;
+      },
+
+      get: function(key) {
+        var entry = cache[key];
+        return entry && entry.value;
+      },
+
+      put: function(key, value, isValid) {
+        if (!cache[key]) {
+          cache[key] = { total: 1, value: value, isValid: isValid };
+        } else {
+          cache[key].total++;
+          cache[key].value = value;
+        }
+      }
+    };
+  }];
+};

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -438,7 +438,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
             if (existingAnimation.state === RUNNING_STATE) {
               normalizeAnimationDetails(element, newAnimation);
             } else {
-              applyGeneratedPreparationClasses(element, isStructural ? event : null, options);
+              applyGeneratedPreparationClasses($$jqLite, element, isStructural ? event : null, options);
 
               event = newAnimation.event = existingAnimation.event;
               options = mergeAnimationDetails(element, existingAnimation, newAnimation);

--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -786,6 +786,7 @@ angular.module('ngAnimate', [], function initAngularHelpers() {
   .factory('$$rAFScheduler', $$rAFSchedulerFactory)
 
   .provider('$$animateQueue', $$AnimateQueueProvider)
+  .provider('$$animateCache', $$AnimateCacheProvider)
   .provider('$$animation', $$AnimationProvider)
 
   .provider('$animateCss', $AnimateCssProvider)

--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -301,7 +301,7 @@ function getDomNode(element) {
   return (element instanceof jqLite) ? element[0] : element;
 }
 
-function applyGeneratedPreparationClasses(element, event, options) {
+function applyGeneratedPreparationClasses($$jqLite, element, event, options) {
   var classes = '';
   if (event) {
     classes = pendClasses(event, EVENT_CLASS_PREFIX, true);

--- a/test/ngAnimate/.eslintrc.json
+++ b/test/ngAnimate/.eslintrc.json
@@ -3,6 +3,7 @@
     "new-cap": "off"
   },
   "globals": {
+    "getDomNode": false,
     "mergeAnimationDetails": false,
     "prepareAnimationOptions": false,
     "applyAnimationStyles": false,

--- a/test/ngAnimate/animateCacheSpec.js
+++ b/test/ngAnimate/animateCacheSpec.js
@@ -1,0 +1,99 @@
+'use strict';
+
+describe('ngAnimate $$animateCache', function() {
+  beforeEach(module('ngAnimate'));
+
+  it('should store the details in a lookup', inject(function($$animateCache) {
+    var data = { 'hello': 'there' };
+    $$animateCache.put('key', data, true);
+    expect($$animateCache.get('key')).toBe(data);
+  }));
+
+  it('should update existing stored details in a lookup', inject(function($$animateCache) {
+    var data = { 'hello': 'there' };
+    $$animateCache.put('key', data, true);
+
+    var otherData = { 'hi': 'you' };
+    $$animateCache.put('key', otherData, true);
+    expect($$animateCache.get('key')).toBe(otherData);
+  }));
+
+  it('should create a special cacheKey based on the element/parent and className relationship', inject(function($$animateCache) {
+    var cacheKey, elm = jqLite('<div></div>');
+    elm.addClass('one two');
+
+    var parent1 = jqLite('<div></div>');
+    parent1.append(elm);
+
+    cacheKey = $$animateCache.cacheKey(getDomNode(elm), 'event');
+    expect(cacheKey).toBe('1 event one two');
+
+    cacheKey = $$animateCache.cacheKey(getDomNode(elm), 'event', 'add');
+    expect(cacheKey).toBe('1 event one two add');
+
+    cacheKey = $$animateCache.cacheKey(getDomNode(elm), 'event', 'add', 'remove');
+    expect(cacheKey).toBe('1 event one two add remove');
+
+    var parent2 = jqLite('<div></div>');
+    parent2.append(elm);
+
+    cacheKey = $$animateCache.cacheKey(getDomNode(elm), 'event');
+    expect(cacheKey).toBe('2 event one two');
+
+    cacheKey = $$animateCache.cacheKey(getDomNode(elm), 'event', 'three', 'four');
+    expect(cacheKey).toBe('2 event one two three four');
+  }));
+
+  it('should keep a count of how many times a cache key has been updated', inject(function($$animateCache) {
+    var data = { 'hello': 'there' };
+    var key = 'key';
+    expect($$animateCache.count(key)).toBe(0);
+
+    $$animateCache.put(key, data, true);
+    expect($$animateCache.count(key)).toBe(1);
+
+    var otherData = { 'other': 'data' };
+    $$animateCache.put(key, otherData, true);
+    expect($$animateCache.count(key)).toBe(2);
+  }));
+
+  it('should flush the cache and the counters', inject(function($$animateCache) {
+    $$animateCache.put('key1', { data: 'value' }, true);
+    $$animateCache.put('key2', { data: 'value' }, true);
+
+    expect($$animateCache.count('key1')).toBe(1);
+    expect($$animateCache.count('key2')).toBe(1);
+
+    $$animateCache.flush();
+
+    expect($$animateCache.get('key1')).toBeFalsy();
+    expect($$animateCache.get('key2')).toBeFalsy();
+
+    expect($$animateCache.count('key1')).toBe(0);
+    expect($$animateCache.count('key2')).toBe(0);
+  }));
+
+  describe('containsCachedAnimationWithoutDuration', function() {
+    it('should return false if the validity of a key is false', inject(function($$animateCache) {
+      var validEntry = { someEssentialProperty: true };
+      var invalidEntry = { someEssentialProperty: false };
+
+      $$animateCache.put('key1', validEntry, true);
+      $$animateCache.put('key2', invalidEntry, false);
+
+      expect($$animateCache.containsCachedAnimationWithoutDuration('key1')).toBe(false);
+      expect($$animateCache.containsCachedAnimationWithoutDuration('key2')).toBe(true);
+    }));
+
+    it('should return false if the key does not exist in the cache', inject(function($$animateCache) {
+      expect($$animateCache.containsCachedAnimationWithoutDuration('key2')).toBe(false);
+
+      $$animateCache.put('key2', {}, false);
+      expect($$animateCache.containsCachedAnimationWithoutDuration('key2')).toBe(true);
+
+      $$animateCache.flush();
+      expect($$animateCache.containsCachedAnimationWithoutDuration('key2')).toBe(false);
+    }));
+  });
+
+});


### PR DESCRIPTION
…imation has no duration

Background:
ngAnimate writes helper classes to DOM elements to see if animations are defined on them. If many
elements have the same definition, and the same parent, we can cache the definition and skip the
application of the helper classes altogether. This helps particularly with large ngRepeat
collections.

Closes #14165
Closes #14166
Closes #16613

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

