### PR TITLE
Provide way to pop to root

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,7 +30,7 @@ https://plnkr.co or similar (you can use this template as a starting point: http
 <!-- Check whether this is still an issue in the most recent stable or in the snapshot AngularJS
 version (https://code.angularjs.org/snapshot/) -->
 
-**Browser:** [all | Chrome XX | Firefox XX | Edge XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ]
+**Browser:** [all | Chrome XX | Firefox XX | Edge XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView | Opera XX ]
 <!-- All browsers where this could be reproduced (and Operating System if relevant) -->
 
 **Anything else:**


### PR DESCRIPTION
Opera is indirectly supported, although not explicitly tested on (see
[here](https://docs.angularjs.org/misc/faq#what-browsers-does-angularjs-work-with-)
for more info), so it doesn't hurt adding it to the list of browsers.

Closes #16801

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

